### PR TITLE
Feat/7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.5'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.17.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/develop/mypick/api/Recommended/controller/RecommendedController.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/controller/RecommendedController.java
@@ -1,0 +1,22 @@
+package com.develop.mypick.api.Recommended.controller;
+
+import com.develop.mypick.api.Recommended.dto.response.RecommendedResponse;
+import com.develop.mypick.api.Recommended.service.RecommendedService;
+import com.develop.mypick.domain.user.entity.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/recommend")
+@RequiredArgsConstructor
+public class RecommendedController {
+
+    private final RecommendedService recommendedService;
+
+    @GetMapping("/")
+    public RecommendedResponse getRecommend(@AuthenticationPrincipal AuthUser user) {
+        RecommendedResponse response = recommendedService.createRecommend(user);
+        return response;
+    }
+}

--- a/src/main/java/com/develop/mypick/api/Recommended/controller/RecommendedController.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/controller/RecommendedController.java
@@ -1,8 +1,9 @@
 package com.develop.mypick.api.Recommended.controller;
 
-import com.develop.mypick.api.Recommended.dto.response.RecommendedResponse;
-import com.develop.mypick.api.Recommended.service.RecommendedService;
+import com.develop.mypick.api.Recommended.dto.response.ChatGptResponse;
+import com.develop.mypick.api.Recommended.service.ChatGptService;
 import com.develop.mypick.domain.user.entity.AuthUser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -12,11 +13,11 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class RecommendedController {
 
-    private final RecommendedService recommendedService;
+    private final ChatGptService chatGptService;
 
     @GetMapping("/")
-    public RecommendedResponse getRecommend(@AuthenticationPrincipal AuthUser user) {
-        RecommendedResponse response = recommendedService.createRecommend(user);
+    public ChatGptResponse getRecommend(@AuthenticationPrincipal AuthUser user) throws JsonProcessingException {
+        ChatGptResponse response = chatGptService.sendChatGpt(user);
         return response;
     }
 }

--- a/src/main/java/com/develop/mypick/api/Recommended/dto/request/ChatGptRequest.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/dto/request/ChatGptRequest.java
@@ -1,0 +1,14 @@
+package com.develop.mypick.api.Recommended.dto.request;
+
+
+import java.util.List;
+
+public record ChatGptRequest(
+        String model,
+        List<MessageRequest> messages,
+        float temperature) {
+
+    public static ChatGptRequest of(String model, List<MessageRequest> messageRequests, float temperature){
+        return new ChatGptRequest(model, messageRequests,temperature);
+    }
+}

--- a/src/main/java/com/develop/mypick/api/Recommended/dto/request/MessageRequest.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/dto/request/MessageRequest.java
@@ -1,0 +1,11 @@
+package com.develop.mypick.api.Recommended.dto.request;
+
+public record MessageRequest(
+        String role,
+        String content
+) {
+    public static MessageRequest toDto(String role, String content){
+        return new MessageRequest(role,content);
+    }
+
+}

--- a/src/main/java/com/develop/mypick/api/Recommended/dto/response/ChatGptResponse.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/dto/response/ChatGptResponse.java
@@ -1,0 +1,15 @@
+package com.develop.mypick.api.Recommended.dto.response;
+
+import com.develop.mypick.domain.Recommended.entity.Recommended;
+import com.develop.mypick.domain.user.entity.AuthUser;
+
+public record ChatGptResponse(
+        Long recommendedId,
+        Long userId,
+        RecommendedResponse response
+) {
+
+    public static ChatGptResponse of(AuthUser user, Recommended recommended,RecommendedResponse response){
+        return new ChatGptResponse(recommended.getId(), user.getId(), response);
+    }
+}

--- a/src/main/java/com/develop/mypick/api/Recommended/dto/response/RecommendedResponse.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/dto/response/RecommendedResponse.java
@@ -1,4 +1,55 @@
 package com.develop.mypick.api.Recommended.dto.response;
 
-public record RecommendedResponse() {
+
+import com.develop.mypick.domain.Recommended.entity.Recommended;
+import com.develop.mypick.domain.user.entity.AuthUser;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RecommendedResponse(
+
+        @JsonProperty("칼로리 ")
+        double cal,
+        @JsonProperty("단백질 ")
+        double protein,
+        @JsonProperty("지방 ")
+        double fat,
+        @JsonProperty("탄수화물 ")
+        double carbs,
+        @JsonProperty("비타민C ")
+        double vitaminC,
+        @JsonProperty("비타민B12 ")
+        double vitaminB12,
+        @JsonProperty("비타민E ")
+        double vitaminE,
+        @JsonProperty("나트륨 ")
+        double sodium,
+        @JsonProperty("칼륨 ")
+        double potassium,
+        @JsonProperty("섬유질 ")
+        double fiber,
+        @JsonProperty("당류 ")
+        double sugar,
+        @JsonProperty("칼슘 ")
+        double calcium
+
+) {
+        public static Recommended toEntity(AuthUser user, RecommendedResponse response){
+                return Recommended.builder()
+                        .cal(response.cal())
+                        .calcium(response.calcium())
+                        .carbs(response.carbs())
+                        .fat(response.fat())
+                        .fiber(response.fiber())
+                        .sugar(response.sugar())
+                        .potassium(response.potassium())
+                        .protein(response.protein())
+                        .sodium(response.sodium())
+                        .vitaminB12(response.vitaminB12())
+                        .vitaminC(response.vitaminC())
+                        .vitaminE(response.vitaminE())
+                        .user(user)
+                        .build();
+        }
 }

--- a/src/main/java/com/develop/mypick/api/Recommended/dto/response/RecommendedResponse.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/dto/response/RecommendedResponse.java
@@ -1,0 +1,4 @@
+package com.develop.mypick.api.Recommended.dto.response;
+
+public record RecommendedResponse() {
+}

--- a/src/main/java/com/develop/mypick/api/Recommended/service/ChatGptService.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/service/ChatGptService.java
@@ -1,0 +1,99 @@
+package com.develop.mypick.api.Recommended.service;
+
+import com.develop.mypick.api.Recommended.dto.response.ChatGptResponse;
+import com.develop.mypick.api.Recommended.dto.response.RecommendedResponse;
+import com.develop.mypick.common.exception.ErrorCode;
+import com.develop.mypick.common.exception.ErrorException;
+import com.develop.mypick.domain.Recommended.entity.Recommended;
+import com.develop.mypick.domain.Recommended.repo.RecommendedRepository;
+import com.develop.mypick.domain.userPhysical.entity.UserPhysical;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.develop.mypick.api.Recommended.dto.request.ChatGptRequest;
+import com.develop.mypick.api.Recommended.dto.request.MessageRequest;
+import com.develop.mypick.api.userPhysical.service.UserPhysicalService;
+import com.develop.mypick.common.config.ChatGptConfig;
+import com.develop.mypick.domain.user.entity.AuthUser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatGptService {
+    private final RecommendedRepository recommendedRepository;
+    private final ChatGptConfig gptConfig;
+    private final UserPhysicalService userPhysicalService;
+
+    @Value("${chatgpt.url}")
+    private String url;
+
+    @Value("${chatgpt.model}")
+    private String model;
+
+    @Transactional
+    public ChatGptResponse sendChatGpt(AuthUser user) throws JsonProcessingException{
+        ObjectMapper mapper = new ObjectMapper();
+        String prompt = createPrompt(user);
+        List<MessageRequest> messages = creatMessages(prompt);
+        ChatGptRequest request = ChatGptRequest.of(model,messages,0.2f);
+        JsonNode result = getJsonNode(request);
+        String json = mapper.writeValueAsString(result);
+        String replaceJson = replaceJson(json);
+        RecommendedResponse readValue = mapper.readValue(replaceJson, new TypeReference<RecommendedResponse>(){});
+        Recommended recommended = RecommendedResponse.toEntity(user,readValue);
+        Recommended save = recommendedRepository.save(recommended);
+        return ChatGptResponse.of(user,save,readValue);
+    }
+
+    public JsonNode getJsonNode(ChatGptRequest request) throws JsonProcessingException{
+        ObjectMapper mapper = new ObjectMapper();
+        HttpHeaders headers = gptConfig.httpHeaders();
+        HttpEntity requestEntity = new HttpEntity(request,headers);
+        String response = gptConfig.restTemplate().postForObject(url,requestEntity,String.class);
+        JsonNode root = mapper.readTree(response);
+        JsonNode result = root.at("/choices/0/message/content");
+        if (result.isNull()){
+            throw new ErrorException(ErrorCode.CHATGPT_ERROR);
+        }
+        return result;
+    }
+
+    public String createPrompt(AuthUser user){
+        UserPhysical userPhysical = userPhysicalService.findUserPhysical(user);
+        String prompt = String.format("형식\\n\\\"기초대사량 : double 칼로리 : double \\n 단백질 : double \\n 탄수화물 : double \\n 지방 : double " +
+                "\\n 나트륨 : double \\n칼륨 : double \\n 섬유질 : double \\n 당류 : double \\n 칼슘 : double\\n비타민C : double" +
+                "\\n비타민B12 : double\\n비타민E : double\\\"\\n예시[- 목표 : %s\\n- 키 : %f cm\\n- 몸무게 : %f kg\\n- 나이 : %d세" +
+                "\\n- 활동지수 : %f\\n- 지병 : %s\\n- 성별 : %s]\n고려 사항[1.형식의 형태를 유지해주세요." +
+                "\\n2.모든 예시 값에 맞게 공식을 이용해서 답변해주세요.\\n3.단위는 작성을 하지마세요.\\n4.소수점 한자리 수까지 작성해주세요.\\n5.열정적으로 답변해주세요.\\n6.json문장 구조로 표현해주세요..]"
+                ,userPhysical.getGoal(),userPhysical.getHeight(),userPhysical.getWeight(),userPhysical.getAge(), userPhysical.getActivityLevel().getValue(),
+                (!userPhysical.getChronicDiseases().isEmpty() ?userPhysical.getChronicDiseases() : "없음") ,userPhysical.getGender().getGender());
+        return prompt;
+    }
+
+    public List<MessageRequest> creatMessages(String prompt){
+        MessageRequest systemRequest = MessageRequest.toDto("system","you are a hospital doctor.");
+        MessageRequest userRequest = MessageRequest.toDto("user",prompt);
+        List<MessageRequest> messages = new ArrayList<>() {{
+            add(systemRequest);
+            add(userRequest);
+        }};
+        return messages;
+    }
+
+    public String replaceJson(String json){
+        return json.substring(1,json.length()-1)
+                .replaceAll("\n"," ")
+                .replaceAll("n"," ")
+                .replaceAll("\\\\"," ");
+    }
+}

--- a/src/main/java/com/develop/mypick/api/Recommended/service/RecommendedService.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/service/RecommendedService.java
@@ -1,0 +1,29 @@
+package com.develop.mypick.api.Recommended.service;
+
+import com.develop.mypick.api.Recommended.dto.response.RecommendedResponse;
+import com.develop.mypick.api.userPhysical.dto.response.UserPhysicalResponse;
+import com.develop.mypick.api.userPhysical.service.UserPhysicalService;
+import com.develop.mypick.domain.Recommended.repo.RecommendedRepository;
+import com.develop.mypick.domain.user.entity.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecommendedService {
+
+    private final RecommendedRepository recommendedRepository;
+
+    private final UserPhysicalService userPhysicalService;
+
+    public RecommendedResponse createRecommend(AuthUser user){
+
+        UserPhysicalResponse userPhysical = userPhysicalService.findUserPhysical(user);
+
+
+    }
+
+    public createPrompt()
+}

--- a/src/main/java/com/develop/mypick/api/Recommended/service/RecommendedService.java
+++ b/src/main/java/com/develop/mypick/api/Recommended/service/RecommendedService.java
@@ -3,27 +3,24 @@ package com.develop.mypick.api.Recommended.service;
 import com.develop.mypick.api.Recommended.dto.response.RecommendedResponse;
 import com.develop.mypick.api.userPhysical.dto.response.UserPhysicalResponse;
 import com.develop.mypick.api.userPhysical.service.UserPhysicalService;
+import com.develop.mypick.common.config.ChatGptConfig;
 import com.develop.mypick.domain.Recommended.repo.RecommendedRepository;
 import com.develop.mypick.domain.user.entity.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.http.HttpHeaders;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class RecommendedService {
 
-    private final RecommendedRepository recommendedRepository;
 
-    private final UserPhysicalService userPhysicalService;
-
-    public RecommendedResponse createRecommend(AuthUser user){
-
-        UserPhysicalResponse userPhysical = userPhysicalService.findUserPhysical(user);
+    private final ChatGptService chatGptService;
 
 
-    }
 
-    public createPrompt()
+
 }

--- a/src/main/java/com/develop/mypick/api/user/controller/UserController.java
+++ b/src/main/java/com/develop/mypick/api/user/controller/UserController.java
@@ -5,8 +5,10 @@ import com.develop.mypick.api.user.dto.request.UserRequest;
 import com.develop.mypick.api.user.dto.response.AccountResponse;
 import com.develop.mypick.api.user.dto.response.TokenResponse;
 import com.develop.mypick.api.user.service.UserService;
+import com.develop.mypick.domain.user.entity.AuthUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -31,8 +33,8 @@ public class UserController {
     }
 
     @GetMapping("/test")
-    public ResponseEntity<String> test(Principal principal){
-        String username = principal.getName().split(":")[0];
-        return ResponseEntity.ok().body(username);
+    public ResponseEntity<Long> test(@AuthenticationPrincipal AuthUser user){
+//        String username = principal.getName().split(":")[0];
+        return ResponseEntity.ok().body(user.getId());
     }
 }

--- a/src/main/java/com/develop/mypick/api/userPhysical/dto/response/UserPhysicalResponse.java
+++ b/src/main/java/com/develop/mypick/api/userPhysical/dto/response/UserPhysicalResponse.java
@@ -1,6 +1,7 @@
 package com.develop.mypick.api.userPhysical.dto.response;
 
 import com.develop.mypick.domain.userPhysical.entity.UserPhysical;
+import com.develop.mypick.domain.userPhysical.enums.ActivityLevel;
 import com.develop.mypick.domain.userPhysical.enums.ChronicDisease;
 import com.develop.mypick.domain.userPhysical.enums.Gender;
 import com.develop.mypick.domain.userPhysical.enums.Goal;
@@ -12,9 +13,10 @@ public record UserPhysicalResponse(Gender gender,
                                    float weight,
                                    int age,
                                    Goal goal,
-                                   Set<ChronicDisease> chronicDiseases) {
+                                   Set<ChronicDisease> chronicDiseases,
+                                   ActivityLevel activityLevel) {
 
-    public static UserPhysicalResponse of(UserPhysical userPhysical){
-        return new UserPhysicalResponse(userPhysical.getGender(), userPhysical.getHeight(), userPhysical.getWeight(), userPhysical.getAge(), userPhysical.getGoal(),userPhysical.getChronicDiseases());
+    public static UserPhysicalResponse from(UserPhysical userPhysical) {
+        return new UserPhysicalResponse(userPhysical.getGender(), userPhysical.getHeight(), userPhysical.getWeight(), userPhysical.getAge(), userPhysical.getGoal(), userPhysical.getChronicDiseases(),userPhysical.getActivityLevel());
     }
 }

--- a/src/main/java/com/develop/mypick/api/userPhysical/dto/response/UserPhysicalResponse.java
+++ b/src/main/java/com/develop/mypick/api/userPhysical/dto/response/UserPhysicalResponse.java
@@ -1,0 +1,20 @@
+package com.develop.mypick.api.userPhysical.dto.response;
+
+import com.develop.mypick.domain.userPhysical.entity.UserPhysical;
+import com.develop.mypick.domain.userPhysical.enums.ChronicDisease;
+import com.develop.mypick.domain.userPhysical.enums.Gender;
+import com.develop.mypick.domain.userPhysical.enums.Goal;
+
+import java.util.Set;
+
+public record UserPhysicalResponse(Gender gender,
+                                   float height,
+                                   float weight,
+                                   int age,
+                                   Goal goal,
+                                   Set<ChronicDisease> chronicDiseases) {
+
+    public static UserPhysicalResponse of(UserPhysical userPhysical){
+        return new UserPhysicalResponse(userPhysical.getGender(), userPhysical.getHeight(), userPhysical.getWeight(), userPhysical.getAge(), userPhysical.getGoal(),userPhysical.getChronicDiseases());
+    }
+}

--- a/src/main/java/com/develop/mypick/api/userPhysical/service/UserPhysicalService.java
+++ b/src/main/java/com/develop/mypick/api/userPhysical/service/UserPhysicalService.java
@@ -1,7 +1,6 @@
 package com.develop.mypick.api.userPhysical.service;
 
 import com.develop.mypick.api.user.dto.request.UserRequest;
-import com.develop.mypick.api.userPhysical.dto.response.UserPhysicalResponse;
 import com.develop.mypick.common.exception.ErrorCode;
 import com.develop.mypick.common.exception.ErrorException;
 import com.develop.mypick.domain.user.entity.AuthUser;
@@ -36,14 +35,10 @@ public class UserPhysicalService {
         userPhysicalRepository.save(userPhysical);
     }
 
-    public UserPhysicalResponse findUserPhysical(AuthUser user){
-        boolean isExist = userPhysicalRepository.existsByAuthUser(user);
-        if (isExist){
-            throw new ErrorException(ErrorCode.EXITS_USER_PHYSICAL);
-        }
+    public UserPhysical findUserPhysical(AuthUser user){
 
-        UserPhysical userPhysical = userPhysicalRepository.findByAuthUser(user);
+        return userPhysicalRepository.findByAuthUser(user)
+                .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_USER));
 
-        return UserPhysicalResponse.of(userPhysical);
     }
 }

--- a/src/main/java/com/develop/mypick/api/userPhysical/service/UserPhysicalService.java
+++ b/src/main/java/com/develop/mypick/api/userPhysical/service/UserPhysicalService.java
@@ -1,6 +1,7 @@
 package com.develop.mypick.api.userPhysical.service;
 
 import com.develop.mypick.api.user.dto.request.UserRequest;
+import com.develop.mypick.api.userPhysical.dto.response.UserPhysicalResponse;
 import com.develop.mypick.common.exception.ErrorCode;
 import com.develop.mypick.common.exception.ErrorException;
 import com.develop.mypick.domain.user.entity.AuthUser;
@@ -33,5 +34,16 @@ public class UserPhysicalService {
                 .goal(request.goal())
                 .build();
         userPhysicalRepository.save(userPhysical);
+    }
+
+    public UserPhysicalResponse findUserPhysical(AuthUser user){
+        boolean isExist = userPhysicalRepository.existsByAuthUser(user);
+        if (isExist){
+            throw new ErrorException(ErrorCode.EXITS_USER_PHYSICAL);
+        }
+
+        UserPhysical userPhysical = userPhysicalRepository.findByAuthUser(user);
+
+        return UserPhysicalResponse.of(userPhysical);
     }
 }

--- a/src/main/java/com/develop/mypick/common/config/ChatGptConfig.java
+++ b/src/main/java/com/develop/mypick/common/config/ChatGptConfig.java
@@ -1,0 +1,18 @@
+package com.develop.mypick.common.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatGptConfig {
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer ";
+    public static final String CHAT_MODEL = "gpt-3.5-turbo";
+    public static final Integer MAX_TOKEN = 300;
+    public static final Boolean STREAM = false;
+    public static final String ROLE = "user";
+    public static final Double TEMPERATURE = 0.6;
+    //public static final Double TOP_P = 1.0;
+    public static final String MEDIA_TYPE = "application/json; charset=UTF-8";
+    //completions : 질답
+    public static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
+}

--- a/src/main/java/com/develop/mypick/common/config/ChatGptConfig.java
+++ b/src/main/java/com/develop/mypick/common/config/ChatGptConfig.java
@@ -7,19 +7,23 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.client.RestTemplate;
 
+
 @Configuration
 public class ChatGptConfig {
 
-    @Value("${openai.secret-key}")
+    @Value("${chatgpt.api-key}")
     private String apiKey;
 
     @Bean
-    public RestTemplate template(){
-        RestTemplate restTemplate = new RestTemplate();
-        restTemplate.getInterceptors().add((request, body, execution) -> {
-            request.getHeaders().add("Authorization", "Bearer " + apiKey);
-            return execution.execute(request, body);
-        });
-        return restTemplate;
+    public RestTemplate restTemplate(){
+        return new RestTemplate();
     }
+    @Bean
+    public HttpHeaders httpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + apiKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
 }

--- a/src/main/java/com/develop/mypick/common/config/ChatGptConfig.java
+++ b/src/main/java/com/develop/mypick/common/config/ChatGptConfig.java
@@ -1,18 +1,25 @@
 package com.develop.mypick.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class ChatGptConfig {
-    public static final String AUTHORIZATION = "Authorization";
-    public static final String BEARER = "Bearer ";
-    public static final String CHAT_MODEL = "gpt-3.5-turbo";
-    public static final Integer MAX_TOKEN = 300;
-    public static final Boolean STREAM = false;
-    public static final String ROLE = "user";
-    public static final Double TEMPERATURE = 0.6;
-    //public static final Double TOP_P = 1.0;
-    public static final String MEDIA_TYPE = "application/json; charset=UTF-8";
-    //completions : 질답
-    public static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
+
+    @Value("${openai.secret-key}")
+    private String apiKey;
+
+    @Bean
+    public RestTemplate template(){
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("Authorization", "Bearer " + apiKey);
+            return execution.execute(request, body);
+        });
+        return restTemplate;
+    }
 }

--- a/src/main/java/com/develop/mypick/common/config/SecurityConfig.java
+++ b/src/main/java/com/develop/mypick/common/config/SecurityConfig.java
@@ -21,7 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final TokenProvider tokenProvider;
-    private String[] allowUrls = {"/", "/api/user/signIn", "/api/user/signUp"};
+    private String[] allowUrls = {"/", "/api/user/signIn", "/api/user/signUp","/error"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -29,7 +29,6 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(allowUrls).permitAll()
-                        .requestMatchers("/api/user/signIn").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/develop/mypick/common/exception/ErrorCode.java
+++ b/src/main/java/com/develop/mypick/common/exception/ErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    //404 에러가 아닌 400 에러 USER 정보가 없다는 정보를 주지 않기위해
+    NOT_FOUND_USER(HttpStatus.BAD_REQUEST,"존재하지 않는 유저 정보입니다"),
+    CHATGPT_ERROR(HttpStatus.BAD_REQUEST,"ChatGPT 자체 오류입니다"),
     EXITS_EMAIL(HttpStatus.BAD_REQUEST,"이미 존재하는 이메일입니다"),
     EXITS_USER_PHYSICAL(HttpStatus.BAD_REQUEST,"유저 피지컬이 이미 존재합니다"),
     LOGIN_FAIL(HttpStatus.BAD_REQUEST,"아이디 혹은 비밀번호를 확인하세요.");

--- a/src/main/java/com/develop/mypick/common/exception/ErrorCode.java
+++ b/src/main/java/com/develop/mypick/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    NOT_FOUND_RECOMMENDED(HttpStatus.NOT_FOUND,"찾을 수 없는 추천 정보입니다."),
     //404 에러가 아닌 400 에러 USER 정보가 없다는 정보를 주지 않기위해
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST,"존재하지 않는 유저 정보입니다"),
     CHATGPT_ERROR(HttpStatus.BAD_REQUEST,"ChatGPT 자체 오류입니다"),

--- a/src/main/java/com/develop/mypick/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/develop/mypick/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.develop.mypick.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ErrorException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(ErrorException e) {
+        ErrorResponse response = new ErrorResponse(e.getErrorCode().name(), e.getMessage());
+        log.error("ErrorException {}", e.getMessage());
+        return new ResponseEntity<>(response, e.getErrorCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleAllException(final Exception e) {
+        ErrorResponse response = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.name(), e.getMessage());
+        log.error("handleAllException {}", e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(JsonProcessingException.class)
+    public ResponseEntity<ErrorResponse> handleAllException(final JsonProcessingException e) {
+        ErrorResponse response = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.name(), "json 오류 발생");
+        log.error("JsonException {}", e.getMessage());
+        return ResponseEntity.internalServerError().body(response);
+    }
+}

--- a/src/main/java/com/develop/mypick/domain/Recommended/entity/Recommended.java
+++ b/src/main/java/com/develop/mypick/domain/Recommended/entity/Recommended.java
@@ -1,4 +1,4 @@
-package com.develop.mypick.domain.RecommendedNutrients.entity;
+package com.develop.mypick.domain.Recommended.entity;
 
 import com.develop.mypick.common.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class RecommendedNutrients extends BaseTimeEntity {
+public class Recommended extends BaseTimeEntity {
 
     @Id
     @Column(name = "id", nullable = false)

--- a/src/main/java/com/develop/mypick/domain/Recommended/entity/Recommended.java
+++ b/src/main/java/com/develop/mypick/domain/Recommended/entity/Recommended.java
@@ -75,4 +75,19 @@ public class Recommended extends BaseTimeEntity {
         this.calcium = calcium;
         this.authUser = user;
     }
+
+    public void updateRecommended(Recommended recommended){
+        this.cal = recommended.getCal();
+        this.protein = recommended.getProtein();
+        this.fat = recommended.getFat();
+        this.carbs = recommended.getCarbs();
+        this.vitaminC = recommended.getVitaminC();
+        this.vitaminB12 = recommended.getVitaminB12();
+        this.vitaminE = recommended.getVitaminE();
+        this.sodium = recommended.getSodium();
+        this.potassium = recommended.getPotassium();
+        this.fiber = recommended.getFiber();
+        this.sugar = recommended.getSugar();
+        this.calcium = recommended.getCalcium();
+    }
 }

--- a/src/main/java/com/develop/mypick/domain/Recommended/entity/Recommended.java
+++ b/src/main/java/com/develop/mypick/domain/Recommended/entity/Recommended.java
@@ -1,10 +1,10 @@
 package com.develop.mypick.domain.Recommended.entity;
 
 import com.develop.mypick.common.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import com.develop.mypick.domain.user.entity.AuthUser;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 public class Recommended extends BaseTimeEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 
@@ -53,4 +54,25 @@ public class Recommended extends BaseTimeEntity {
     @Column(name = "calcium", nullable = false)
     private double calcium;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private AuthUser authUser;
+
+    @Builder
+    public Recommended(Long id, double cal, double protein, double fat, double carbs, double vitaminC, double vitaminB12, double vitaminE, double sodium, double potassium, double fiber, double sugar, double calcium,AuthUser user) {
+        this.id = id;
+        this.cal = cal;
+        this.protein = protein;
+        this.fat = fat;
+        this.carbs = carbs;
+        this.vitaminC = vitaminC;
+        this.vitaminB12 = vitaminB12;
+        this.vitaminE = vitaminE;
+        this.sodium = sodium;
+        this.potassium = potassium;
+        this.fiber = fiber;
+        this.sugar = sugar;
+        this.calcium = calcium;
+        this.authUser = user;
+    }
 }

--- a/src/main/java/com/develop/mypick/domain/Recommended/repo/RecommendedRepository.java
+++ b/src/main/java/com/develop/mypick/domain/Recommended/repo/RecommendedRepository.java
@@ -1,7 +1,12 @@
 package com.develop.mypick.domain.Recommended.repo;
 
 import com.develop.mypick.domain.Recommended.entity.Recommended;
+import com.develop.mypick.domain.user.entity.AuthUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RecommendedRepository extends JpaRepository<Recommended, Long> {
+    Boolean existsByAuthUser(AuthUser user);
+    Optional<Recommended> findByAuthUser(AuthUser user);
 }

--- a/src/main/java/com/develop/mypick/domain/Recommended/repo/RecommendedRepository.java
+++ b/src/main/java/com/develop/mypick/domain/Recommended/repo/RecommendedRepository.java
@@ -1,0 +1,7 @@
+package com.develop.mypick.domain.Recommended.repo;
+
+import com.develop.mypick.domain.Recommended.entity.Recommended;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendedRepository extends JpaRepository<Recommended, Long> {
+}

--- a/src/main/java/com/develop/mypick/domain/RecommendedNutrients/entity/RecommendedNutrients.java
+++ b/src/main/java/com/develop/mypick/domain/RecommendedNutrients/entity/RecommendedNutrients.java
@@ -1,0 +1,56 @@
+package com.develop.mypick.domain.RecommendedNutrients.entity;
+
+import com.develop.mypick.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class RecommendedNutrients extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "cal", nullable = false)
+    private double cal;
+
+    @Column(name = "protein", nullable = false)
+    private double protein;
+
+    @Column(name = "fat", nullable = false)
+    private double fat;
+
+    @Column(name = "carbs", nullable = false)
+    private double carbs;
+
+    @Column(name = "vitaminC", nullable = false)
+    private double vitaminC;
+
+    @Column(name = "vitaminB12", nullable = false)
+    private double vitaminB12;
+
+    @Column(name = "vitaminE", nullable = false)
+    private double vitaminE;
+
+    @Column(name = "sodium", nullable = false)
+    private double sodium;
+
+    @Column(name = "potassium", nullable = false)
+    private double potassium;
+
+    @Column(name = "fiber", nullable = false)
+    private double fiber;
+
+    @Column(name = "sugar", nullable = false)
+    private double sugar;
+
+    @Column(name = "calcium", nullable = false)
+    private double calcium;
+
+}

--- a/src/main/java/com/develop/mypick/domain/userPhysical/entity/UserPhysical.java
+++ b/src/main/java/com/develop/mypick/domain/userPhysical/entity/UserPhysical.java
@@ -4,6 +4,7 @@ package com.develop.mypick.domain.userPhysical.entity;
 import com.develop.mypick.common.entity.BaseTimeEntity;
 
 import com.develop.mypick.domain.user.entity.AuthUser;
+import com.develop.mypick.domain.userPhysical.enums.ActivityLevel;
 import com.develop.mypick.domain.userPhysical.enums.ChronicDisease;
 import com.develop.mypick.domain.userPhysical.enums.Gender;
 import com.develop.mypick.domain.userPhysical.enums.Goal;
@@ -41,6 +42,10 @@ public class UserPhysical extends BaseTimeEntity {
     @Column(name = "goal", nullable = false)
     private Goal goal;
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "activity_level", nullable = false)
+    private ActivityLevel activityLevel;
+
     @ElementCollection
     @Enumerated(value = EnumType.STRING)
     @Column(name = "chronic_diseases")
@@ -52,7 +57,7 @@ public class UserPhysical extends BaseTimeEntity {
     private AuthUser authUser;
 
     @Builder
-    public UserPhysical(Long id, Gender gender, float height, float weight, int age, Goal goal, Set<ChronicDisease> chronicDiseases, AuthUser authUser) {
+    public UserPhysical(Long id, Gender gender, float height, float weight, int age, Goal goal,ActivityLevel activityLevel, Set<ChronicDisease> chronicDiseases, AuthUser authUser) {
         this.id = id;
         this.gender = gender;
         this.height = height;
@@ -60,6 +65,7 @@ public class UserPhysical extends BaseTimeEntity {
         this.age = age;
         this.goal = goal;
         this.chronicDiseases = chronicDiseases;
+        this.activityLevel = activityLevel;
         this.authUser = authUser;
     }
 

--- a/src/main/java/com/develop/mypick/domain/userPhysical/enums/ActivityLevel.java
+++ b/src/main/java/com/develop/mypick/domain/userPhysical/enums/ActivityLevel.java
@@ -1,0 +1,21 @@
+package com.develop.mypick.domain.userPhysical.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ActivityLevel {
+
+    SEDENTARY("아주 낮음", 1.2f),
+    LIGHTLY("낮음", 1.375f),
+    MODERATELY("보통", 1.55f),
+    VERY("활동적", 1.725f),
+    EXTRA("매우 활동적", 1.9f);
+
+    private final String activityLevel;
+    private final float value;
+
+    ActivityLevel(String activityLevel, float value) {
+        this.activityLevel = activityLevel;
+        this.value = value;
+    }
+}

--- a/src/main/java/com/develop/mypick/domain/userPhysical/enums/ChronicDisease.java
+++ b/src/main/java/com/develop/mypick/domain/userPhysical/enums/ChronicDisease.java
@@ -9,7 +9,6 @@ public enum ChronicDisease {
     DIABETES("당뇨"),
     HEART_DISEASE("심장병"),
     OSTEOPOROSIS("골다공증"),
-    ARTHRITIS("관절염"),
     KIDNEY_DISEASE("신장 질환"),
     STROKE("뇌졸증");
 

--- a/src/main/java/com/develop/mypick/domain/userPhysical/repo/UserPhysicalRepository.java
+++ b/src/main/java/com/develop/mypick/domain/userPhysical/repo/UserPhysicalRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserPhysicalRepository extends JpaRepository<UserPhysical, Long> {
     boolean existsByAuthUser(AuthUser user);
+
+    UserPhysical findByAuthUser(AuthUser user);
 }

--- a/src/main/java/com/develop/mypick/domain/userPhysical/repo/UserPhysicalRepository.java
+++ b/src/main/java/com/develop/mypick/domain/userPhysical/repo/UserPhysicalRepository.java
@@ -4,8 +4,11 @@ import com.develop.mypick.domain.user.entity.AuthUser;
 import com.develop.mypick.domain.userPhysical.entity.UserPhysical;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPhysicalRepository extends JpaRepository<UserPhysical, Long> {
     boolean existsByAuthUser(AuthUser user);
 
-    UserPhysical findByAuthUser(AuthUser user);
+
+    Optional<UserPhysical> findByAuthUser(AuthUser user);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,5 @@ spring:
     token-milliseconds:
       rtk: 600000
       atk: 3000000
+chatgpt:
+  api-key: ${CHATGPT_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,4 +27,6 @@ spring:
       rtk: 600000
       atk: 3000000
 chatgpt:
+  model : ${CHATGPT_MODEL}
   api-key: ${CHATGPT_KEY}
+  url: ${CHATGPT_URL}


### PR DESCRIPTION
### 📃 작업 내용
- ChatGPT 외부 API 정보 가져오기
- 추천 정보가 있을 시 새로운 정보로 수정하기
### ✏️작업 설명
- ObjectMapper를 통해 ChatGPT API에 프롬프트를 보내서 데이터를 가져온다.
- ChatGPT config를 미리 만들어서 헤더 정보 저장
- 불러온 데이터 중에서 원하는 정보만을 추출한다.(json 추출)
- ChatGPT 예외처리
- GlobalExceptionHandler 추가 및 jsonException 내용 추가
### ✔️ 테스트
![image](https://github.com/user-attachments/assets/35202db9-5d00-4c18-8e2f-78ce58b7c6c3)
